### PR TITLE
fix message lost

### DIFF
--- a/pkg/core/context/context_channel.go
+++ b/pkg/core/context/context_channel.go
@@ -172,14 +172,8 @@ func (ctx *ChannelContext) Send2Group(moduleType string, message model.Message) 
 		case ch <- message:
 		default:
 			log.LOGGER.Warnf("the message channel is full, message: %+v", message)
-			for {
-				if len(ch) < cap(ch) {
-					log.LOGGER.Infof("current channel length: %d, retry to send message to channel: %+v", len(ch), message)
-					ch <- message
-					log.LOGGER.Infof("retry to send message successfully, message: %+v", message)
-					break
-				}
-				time.Sleep(time.Millisecond * 10)
+			select {
+			case ch <- message:
 			}
 		}
 	}

--- a/pkg/core/context/context_channel.go
+++ b/pkg/core/context/context_channel.go
@@ -171,7 +171,16 @@ func (ctx *ChannelContext) Send2Group(moduleType string, message model.Message) 
 		select {
 		case ch <- message:
 		default:
-			log.LOGGER.Warnf("the message channel is full, just drop this message:%+v", message)
+			log.LOGGER.Warnf("the message channel is full, message: %+v", message)
+			for {
+				if len(ch) < cap(ch) {
+					log.LOGGER.Infof("current channel length: %d, retry to send message to channel: %+v", len(ch), message)
+					ch <- message
+					log.LOGGER.Infof("retry to send message successfully, message: %+v", message)
+					break
+				}
+				time.Sleep(time.Millisecond * 10)
+			}
 		}
 	}
 	if channelList := ctx.getTypeChannel(moduleType); channelList != nil {


### PR DESCRIPTION
Currently the `Send2Group` function will lost message when the channel is full.
Actually we need to wait for the idle channel so that we will not lose messages.