### PR TITLE
pkg/core/socket/broker: fix dropped errors

### DIFF
--- a/pkg/core/socket/broker/broker.go
+++ b/pkg/core/socket/broker/broker.go
@@ -69,6 +69,11 @@ func (broker *RemoteBroker) Receive(conn wrapper.Conn) (model.Message, error) {
 	var message model.Message
 	for {
 		err := conn.SetReadDeadline(time.Time{})
+		if err != nil {
+			klog.Errorf("failed to set read deadline: %+v", err)
+			return model.Message{}, fmt.Errorf("failed to set read deadline: %v", err)
+		}
+
 		err = conn.ReadJSON(&message)
 		if err != nil {
 			klog.Errorf("failed to read, error:%+v", err)
@@ -81,6 +86,10 @@ func (broker *RemoteBroker) Receive(conn wrapper.Conn) (model.Message, error) {
 		}
 
 		err = broker.keeper.SendToKeepChannel(message)
+		if err != nil {
+			klog.Errorf("failed to send to keep channel: %+v", err)
+			return model.Message{}, fmt.Errorf("failed to send to keep channel: %+v", err)
+		}
 	}
 }
 
@@ -101,6 +110,10 @@ func (broker *RemoteBroker) SendSyncInternal(conn wrapper.Conn, message model.Me
 
 	deadline := time.Now().Add(timeout)
 	err = conn.SetReadDeadline(deadline)
+	if err != nil {
+		klog.Errorf("failed to set read deadline: %+v", err)
+		return model.Message{}, fmt.Errorf("failed to set read deadline: %v", err)
+	}
 	var response model.Message
 	err = conn.ReadJSON(&response)
 	if err != nil {


### PR DESCRIPTION
This fixes three dropped `err` variables in `pkg/core/socket/broker`. Local logging and old-school error wrapping conventions are maintained. Tests pass before and after changes.