### PR TITLE
fix: release pipe store lock on missing delete

### DIFF
--- a/pkg/core/socket/store/pipe.go
+++ b/pkg/core/socket/store/pipe.go
@@ -37,6 +37,7 @@ func (s *PipeStore) Delete(module string) {
 	_, exist := s.pipeMap[module]
 	if !exist {
 		klog.Warningf("failed to get pipe, module: %s", module)
+		s.pipeMapLock.Unlock()
 		return
 	}
 	delete(s.pipeMap, module)

--- a/pkg/core/socket/store/pipe_test.go
+++ b/pkg/core/socket/store/pipe_test.go
@@ -1,0 +1,27 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDeleteMissingPipeReleasesLock(t *testing.T) {
+	store := NewPipeStore()
+	deleted := make(chan struct{})
+
+	go func() {
+		store.Delete("missing")
+		close(deleted)
+	}()
+
+	select {
+	case <-deleted:
+	case <-time.After(time.Second):
+		t.Fatal("Delete blocked while handling a missing pipe")
+	}
+
+	store.Add("module", "pipe")
+	if _, err := store.Get("module"); err != nil {
+		t.Fatalf("Get failed after deleting a missing pipe: %v", err)
+	}
+}

--- a/pkg/core/socket/store/pipe_test.go
+++ b/pkg/core/socket/store/pipe_test.go
@@ -20,8 +20,19 @@ func TestDeleteMissingPipeReleasesLock(t *testing.T) {
 		t.Fatal("Delete blocked while handling a missing pipe")
 	}
 
-	store.Add("module", "pipe")
-	if _, err := store.Get("module"); err != nil {
-		t.Fatalf("Get failed after deleting a missing pipe: %v", err)
+	operationResult := make(chan error, 1)
+	go func() {
+		store.Add("module", "pipe")
+		_, err := store.Get("module")
+		operationResult <- err
+	}()
+
+	select {
+	case err := <-operationResult:
+		if err != nil {
+			t.Fatalf("Get failed after deleting a missing pipe: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("pipe store lock remained held after deleting a missing pipe")
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Releases `pipeMapLock` before `PipeStore.Delete()` returns for an absent module. This prevents later pipe store operations from blocking indefinitely.

**Which issue(s) this PR fixes**:

Fixes #42

**Validation**:

Added a regression test for deleting a missing pipe and verified `go test ./pkg/core/socket/store` plus `go test ./...` on macOS.